### PR TITLE
Add numeric-only validation support on fields

### DIFF
--- a/example1/example1.go
+++ b/example1/example1.go
@@ -33,6 +33,9 @@ var screen1 = go3270.Screen{
 	{Row: 6, Col: 0, Content: "Password  . . . ."},
 	{Row: 6, Col: 19, Name: "password", Write: true, Hidden: true},
 	{Row: 6, Col: 40}, // field "stop" character
+	{Row: 7, Col: 0, Content: "EmployeeId . . . ."},
+	{Row: 7, Col: 19, Name: "employeeId", Write: true, Highlighting: go3270.Underscore, NumericOnly: true},
+	{Row: 7, Col: 40}, // field "stop" character
 	{Row: 8, Col: 0, Content: "Press"},
 	{Row: 8, Col: 6, Intense: true, Content: "enter"},
 	{Row: 8, Col: 12, Content: "to submit your name."},

--- a/screen.go
+++ b/screen.go
@@ -40,6 +40,9 @@ type Field struct {
 	// password input field).
 	Hidden bool
 
+	// NumericOnly if set only allows numeric input to be written to the field
+	NumericOnly bool
+
 	// Color is the field color. The default value is the default color.
 	Color Color
 
@@ -193,7 +196,7 @@ func buildField(f Field) []byte {
 	if f.Color == DefaultColor && f.Highlighting == DefaultHighlight {
 		// this is a traditional field, issue a normal sf command
 		buf.WriteByte(0x1d) // sf - "start field"
-		buf.WriteByte(sfAttribute(f.Write, f.Intense, f.Hidden, f.Autoskip))
+		buf.WriteByte(sfAttribute(f.Write, f.Intense, f.Hidden, f.Autoskip, f.NumericOnly))
 		return buf.Bytes()
 	}
 
@@ -210,7 +213,7 @@ func buildField(f Field) []byte {
 
 	// Write the basic field attribute
 	buf.WriteByte(0xc0)
-	buf.WriteByte(sfAttribute(f.Write, f.Intense, f.Hidden, f.Autoskip))
+	buf.WriteByte(sfAttribute(f.Write, f.Intense, f.Hidden, f.Autoskip, f.NumericOnly))
 
 	// Write the highlighting attribute
 	if f.Highlighting != DefaultHighlight {
@@ -228,7 +231,7 @@ func buildField(f Field) []byte {
 }
 
 // sfAttribute builds the attribute byte for the "start field" 3270 command
-func sfAttribute(write, intense, hidden, skip bool) byte {
+func sfAttribute(write, intense, hidden, skip, numeric bool) byte {
 	var attribute byte
 	if !write {
 		attribute |= 1 << 5 // set "bit 2"
@@ -247,6 +250,9 @@ func sfAttribute(write, intense, hidden, skip bool) byte {
 	if hidden {
 		attribute |= 1 << 3 // set "bit 4"
 		attribute |= 1 << 2 // set "bit 5"
+	}
+	if numeric {
+		attribute |= 1 << 4 // set "bit 3"
 	}
 	// Fill in top 2 bits with appropriate values
 	attribute = codes[attribute]


### PR DESCRIPTION
Added numeric-only input validation on client/terminal side for fields.
If field is writable and bit 3 on the SF attribute is set to 1 the terminal only accepts numeric input.